### PR TITLE
Add basic bottom navigation

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -49,6 +49,7 @@ dependencies {
     implementation(libs.androidx.ui.graphics)
     implementation(libs.androidx.ui.tooling.preview)
     implementation(libs.androidx.material3)
+    implementation(libs.androidx.material.icons.extended)
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)

--- a/app/src/main/java/net/kino2718/podcast/MainActivity.kt
+++ b/app/src/main/java/net/kino2718/podcast/MainActivity.kt
@@ -6,12 +6,21 @@ import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.NavigationBar
+import androidx.compose.material3.NavigationBarItem
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.rememberSaveable
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import net.kino2718.podcast.ui.theme.PodCastTheme
+import net.kino2718.podcast.ui.NavItem
+import net.kino2718.podcast.ui.home.HomeScreen
+import net.kino2718.podcast.ui.search.SearchScreen
 
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -19,11 +28,32 @@ class MainActivity : ComponentActivity() {
         enableEdgeToEdge()
         setContent {
             PodCastTheme {
-                Scaffold(modifier = Modifier.fillMaxSize()) { innerPadding ->
-                    Greeting(
-                        name = "Android",
-                        modifier = Modifier.padding(innerPadding)
-                    )
+                var current by rememberSaveable { mutableStateOf(NavItem.HOME) }
+
+                Scaffold(
+                    modifier = Modifier.fillMaxSize(),
+                    bottomBar = {
+                        NavigationBar {
+                            NavItem.entries.forEach { item ->
+                                NavigationBarItem(
+                                    selected = current == item,
+                                    onClick = { current = item },
+                                    icon = {
+                                        androidx.compose.material3.Icon(
+                                            imageVector = item.icon,
+                                            contentDescription = item.label
+                                        )
+                                    },
+                                    label = { Text(item.label) }
+                                )
+                            }
+                        }
+                    }
+                ) { innerPadding ->
+                    when (current) {
+                        NavItem.HOME -> HomeScreen(Modifier.padding(innerPadding))
+                        NavItem.SEARCH -> SearchScreen(Modifier.padding(innerPadding))
+                    }
                 }
             }
         }
@@ -40,8 +70,8 @@ fun Greeting(name: String, modifier: Modifier = Modifier) {
 
 @Preview(showBackground = true)
 @Composable
-fun GreetingPreview() {
+fun HomePreview() {
     PodCastTheme {
-        Greeting("Android")
+        HomeScreen()
     }
 }

--- a/app/src/main/java/net/kino2718/podcast/ui/NavItem.kt
+++ b/app/src/main/java/net/kino2718/podcast/ui/NavItem.kt
@@ -1,0 +1,11 @@
+package net.kino2718.podcast.ui
+
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Home
+import androidx.compose.material.icons.filled.Search
+import androidx.compose.ui.graphics.vector.ImageVector
+
+enum class NavItem(val label: String, val icon: ImageVector) {
+    HOME("Home", Icons.Default.Home),
+    SEARCH("Search", Icons.Default.Search)
+}

--- a/app/src/main/java/net/kino2718/podcast/ui/home/HomeScreen.kt
+++ b/app/src/main/java/net/kino2718/podcast/ui/home/HomeScreen.kt
@@ -1,0 +1,15 @@
+package net.kino2718.podcast.ui.home
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+
+@Composable
+fun HomeScreen(modifier: Modifier = Modifier) {
+    Box(modifier = modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+        Text(text = "Home Screen")
+    }
+}

--- a/app/src/main/java/net/kino2718/podcast/ui/search/SearchScreen.kt
+++ b/app/src/main/java/net/kino2718/podcast/ui/search/SearchScreen.kt
@@ -1,0 +1,15 @@
+package net.kino2718.podcast.ui.search
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+
+@Composable
+fun SearchScreen(modifier: Modifier = Modifier) {
+    Box(modifier = modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+        Text(text = "Search Screen")
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -24,6 +24,7 @@ androidx-ui-tooling-preview = { group = "androidx.compose.ui", name = "ui-toolin
 androidx-ui-test-manifest = { group = "androidx.compose.ui", name = "ui-test-manifest" }
 androidx-ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-test-junit4" }
 androidx-material3 = { group = "androidx.compose.material3", name = "material3" }
+androidx-material-icons-extended = { group = "androidx.compose.material", name = "material-icons-extended" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
## Summary
- implement enum `NavItem` for bottom navigation items
- create simple HomeScreen and SearchScreen
- wire up NavigationBar in `MainActivity`
- include Material icons dependency

## Testing
- `./gradlew assembleDebug` *(fails: SDK location not found)*
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6854f24d6590832193bdba4e73519819