### PR TITLE
Implement podcast search screen

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -50,6 +50,7 @@ dependencies {
     implementation(libs.androidx.ui.tooling.preview)
     implementation(libs.androidx.material3)
     implementation(libs.androidx.material.icons.extended)
+    implementation(libs.okhttp)
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)

--- a/app/src/main/java/net/kino2718/podcast/ui/search/SearchScreen.kt
+++ b/app/src/main/java/net/kino2718/podcast/ui/search/SearchScreen.kt
@@ -1,15 +1,81 @@
 package net.kino2718.podcast.ui.search
 
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Search
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import org.json.JSONObject
+import java.net.URLEncoder
 
 @Composable
 fun SearchScreen(modifier: Modifier = Modifier) {
-    Box(modifier = modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-        Text(text = "Search Screen")
+    var query by remember { mutableStateOf("") }
+    var results by remember { mutableStateOf(listOf<String>()) }
+    val scope = rememberCoroutineScope()
+
+    Column(modifier = modifier.fillMaxSize().padding(16.dp)) {
+        OutlinedTextField(
+            value = query,
+            onValueChange = { query = it },
+            modifier = Modifier.fillMaxWidth(),
+            singleLine = true,
+            label = { Text("Search Podcasts") },
+            trailingIcon = {
+                IconButton(onClick = {
+                    scope.launch {
+                        results = searchPodcasts(query)
+                    }
+                }) {
+                    Icon(Icons.Default.Search, contentDescription = "Search")
+                }
+            }
+        )
+
+        Spacer(modifier = Modifier.height(16.dp))
+
+        LazyColumn(modifier = Modifier.fillMaxSize()) {
+            items(results) { name ->
+                Text(text = name, modifier = Modifier.padding(vertical = 4.dp))
+            }
+        }
+    }
+}
+
+private suspend fun searchPodcasts(keyword: String): List<String> {
+    if (keyword.isBlank()) return emptyList()
+    val client = OkHttpClient()
+    val encoded = URLEncoder.encode(keyword, "UTF-8")
+    val request = Request.Builder()
+        .url("https://itunes.apple.com/search?media=podcast&term=$encoded")
+        .build()
+    return withContext(Dispatchers.IO) {
+        runCatching { client.newCall(request).execute() }.getOrNull()?.use { response ->
+            if (!response.isSuccessful) return@withContext emptyList<String>()
+            val body = response.body?.string() ?: return@withContext emptyList<String>()
+            val json = JSONObject(body)
+            val results = json.getJSONArray("results")
+            List(results.length()) { index ->
+                results.getJSONObject(index).optString("collectionName")
+            }
+        } ?: emptyList()
     }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -8,6 +8,7 @@ espressoCore = "3.6.1"
 lifecycleRuntimeKtx = "2.9.1"
 activityCompose = "1.10.1"
 composeBom = "2024.09.00"
+okhttp = "4.12.0"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -25,6 +26,7 @@ androidx-ui-test-manifest = { group = "androidx.compose.ui", name = "ui-test-man
 androidx-ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-test-junit4" }
 androidx-material3 = { group = "androidx.compose.material3", name = "material3" }
 androidx-material-icons-extended = { group = "androidx.compose.material", name = "material-icons-extended" }
+okhttp = { group = "com.squareup.okhttp3", name = "okhttp", version.ref = "okhttp" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
## Summary
- add OkHttp dependency
- create search screen with a text field and search button
- fetch podcast names from Apple Podcasts Search API

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6854fffa63a483218f70e104223906c8