### PR TITLE
Implement PodCastScreen with RSS parsing

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -72,6 +72,7 @@ dependencies {
     implementation(libs.androidx.navigation.compose)
     // serialization
     implementation(libs.kotlinx.serialization.json)
+    implementation(libs.xmlutil.serialization)
     // その他
     implementation(libs.okhttp)
     implementation(libs.coil.compose)

--- a/app/src/main/java/net/kino2718/podcast/ui/podcast/PodCastScreen.kt
+++ b/app/src/main/java/net/kino2718/podcast/ui/podcast/PodCastScreen.kt
@@ -1,20 +1,64 @@
 package net.kino2718.podcast.ui.podcast
 
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.dimensionResource
+import androidx.lifecycle.viewmodel.compose.viewModel
+import net.kino2718.podcast.R
 
 @Composable
 fun PodCastScreen(
     feedUrl: String,
     modifier: Modifier = Modifier,
+    viewModel: PodCastViewModel = viewModel(),
 ) {
+    val uiState by viewModel.uiState.collectAsState()
+
+    LaunchedEffect(feedUrl) {
+        viewModel.load(feedUrl)
+    }
+
     Scaffold { innerPadding ->
-        Text(
-            text = feedUrl,
-            modifier = modifier.padding(innerPadding)
-        )
+        Column(modifier = modifier.padding(innerPadding)) {
+            Text(
+                text = uiState.channelTitle,
+                style = MaterialTheme.typography.titleLarge
+            )
+            Text(
+                text = uiState.channelAuthor,
+                style = MaterialTheme.typography.titleMedium,
+                modifier = Modifier.padding(bottom = dimensionResource(R.dimen.padding_medium))
+            )
+
+            LazyColumn {
+                items(uiState.items) { item ->
+                    Column(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(vertical = dimensionResource(R.dimen.padding_small))
+                    ) {
+                        Text(
+                            text = item.title,
+                            style = MaterialTheme.typography.titleMedium
+                        )
+                        Text(
+                            text = item.url,
+                            style = MaterialTheme.typography.bodySmall
+                        )
+                    }
+                }
+            }
+        }
     }
 }

--- a/app/src/main/java/net/kino2718/podcast/ui/podcast/PodCastViewModel.kt
+++ b/app/src/main/java/net/kino2718/podcast/ui/podcast/PodCastViewModel.kt
@@ -1,0 +1,103 @@
+package net.kino2718.podcast.ui.podcast
+
+import android.app.Application
+import androidx.lifecycle.AndroidViewModel
+import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import net.kino2718.podcast.utils.MyLog
+import nl.adaptivity.xmlutil.serialization.XML
+import nl.adaptivity.xmlutil.serialization.XmlSerialName
+import nl.adaptivity.xmlutil.serialization.XmlElement
+import nl.adaptivity.xmlutil.serialization.XmlAttr
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import okhttp3.OkHttpClient
+import okhttp3.Request
+
+@Serializable
+@XmlSerialName("rss", namespace = "", prefix = "")
+private data class Rss(
+    @XmlElement(true)
+    val channel: Channel = Channel()
+)
+
+@Serializable
+private data class Channel(
+    val title: String? = null,
+    @SerialName("itunes:author") val author: String? = null,
+    @XmlElement(true)
+    val item: List<Item> = emptyList()
+)
+
+@Serializable
+private data class Item(
+    val title: String? = null,
+    val enclosure: Enclosure? = null
+)
+
+@Serializable
+private data class Enclosure(
+    @XmlAttr
+    val url: String? = null
+)
+
+data class ItemState(val title: String, val url: String)
+
+data class PodCastUIState(
+    val channelTitle: String = "",
+    val channelAuthor: String = "",
+    val items: List<ItemState> = emptyList()
+)
+
+class PodCastViewModel(app: Application) : AndroidViewModel(app) {
+    private val _uiState = MutableStateFlow(PodCastUIState())
+    val uiState = _uiState.asStateFlow()
+
+    fun load(feedUrl: String) {
+        if (feedUrl.isBlank()) return
+        viewModelScope.launch(Dispatchers.IO) {
+            val client = OkHttpClient()
+            val request = Request.Builder().url(feedUrl).build()
+            val response = try {
+                client.newCall(request).execute()
+            } catch (e: Exception) {
+                MyLog.e(TAG, "load error: $e")
+                null
+            }
+            response?.use { r ->
+                if (r.isSuccessful) {
+                    val body = r.body?.string()
+                    body?.let { xmlStr ->
+                        val xml = XML { }
+                        val rss = try {
+                            xml.decodeFromString<Rss>(xmlStr)
+                        } catch (e: Exception) {
+                            MyLog.e(TAG, "parse error: $e")
+                            null
+                        }
+                        rss?.let { res ->
+                            val items = res.channel.item.map { i ->
+                                ItemState(
+                                    title = i.title ?: "",
+                                    url = i.enclosure?.url ?: ""
+                                )
+                            }
+                            _uiState.value = PodCastUIState(
+                                channelTitle = res.channel.title ?: "",
+                                channelAuthor = res.channel.author ?: "",
+                                items = items
+                            )
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    companion object {
+        private const val TAG = "PodCastViewModel"
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -19,6 +19,7 @@ kotlinxSerializationJson = "1.7.3"
 # その他
 okhttp = "4.12.0"
 coilCompose = "2.4.0"
+xmlutil = "0.91.1"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -48,6 +49,7 @@ kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serializa
 # その他
 okhttp = { group = "com.squareup.okhttp3", name = "okhttp", version.ref = "okhttp" }
 coil-compose = { group = "io.coil-kt", name = "coil-compose", version.ref = "coilCompose" }
+xmlutil-serialization = { group = "io.github.pdvrieze.xmlutil", name = "serialization", version.ref = "xmlutil" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
## Summary
- add xmlutil library for XML serialization
- implement PodCastViewModel to fetch and parse podcast RSS feeds
- show parsed podcast info in PodCastScreen

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68561afe79b88321a9b9dccec7c806ab